### PR TITLE
fix: `git fetch` on Complete Clones

### DIFF
--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -74,7 +74,7 @@ java -jar bazel-diff.jar generate-hashes --workspacePath="${WORKSPACE_PATH}" "${
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-java -jar bazel-diff.jar generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_with_pr_branch_out}" --output_base=1
+java -jar bazel-diff.jar generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 java -jar bazel-diff.jar get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -77,8 +77,7 @@ git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash
 java -jar bazel-diff.jar generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_with_pr_branch_out}" --output_base=1
 
 # Compute impacted targets
-java -jar bazel-diff.jar get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"
-
+java -jar bazel-diff.jar get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}"
 num_impacted_targets=$(wc -l <"${impacted_targets_out}")
 echo "Computed ${num_impacted_targets} targets for sha ${pr_branch_head_sha}"
 

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -29,10 +29,6 @@ if [[ -z ${WORKSPACE_PATH} ]]; then
 	exit 2
 fi
 
-logIfVerbose "Fetching all remotes..."
-git fetch --all --quiet
-logIfVerbose "...done!"
-
 # Install the bazel-diff JAR. Avoid cloning the repo, as there will be conflicting WORKSPACES.
 curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
 

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -35,27 +35,24 @@ curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/
 fetchRemoteGitHistory "${MERGE_INSTANCE_BRANCH}"
 fetchRemoteGitHistory "${PR_BRANCH}"
 
+# Log the tip of the merge instance and PR branches.
 merge_instance_branch_head_sha=$(git rev-parse "${MERGE_INSTANCE_BRANCH}")
 logIfVerbose "Merge Instance Branch Head= ${merge_instance_branch_head_sha}"
-
 pr_branch_head_sha=$(git rev-parse "${PR_BRANCH}")
 logIfVerbose "PR Branch Head= ${pr_branch_head_sha}"
 
-# Find the merge base of the two branches
+# Log the commits between the merge base and the merge instance's HEAD.
+git switch "${PR_BRANCH}"
 merge_base_sha=$(git merge-base "${merge_instance_branch_head_sha}" "${pr_branch_head_sha}")
 logIfVerbose "Merge Base= ${merge_base_sha}"
-
-# Find the number of commits between the merge base and the merge instance's HEAD
 merge_instance_depth=$(git rev-list "${merge_base_sha}".."${merge_instance_branch_head_sha}" | wc -l)
 logIfVerbose "Merge Instance Depth= ${merge_instance_depth}"
-
 git switch "${MERGE_INSTANCE_BRANCH}"
 ifVerbose git log -n "${merge_instance_depth}" --oneline
 
-# Find the number of commits between the merge base and the PR's HEAD
+# Log the number of commits between the merge base and the PR's HEAD
 pr_depth=$(git rev-list "${merge_base_sha}".."${pr_branch_head_sha}" | wc -l)
 logIfVerbose "PR Depth= ${pr_depth}"
-
 git switch "${PR_BRANCH}"
 ifVerbose git log -n "${pr_depth}" --oneline
 

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -42,7 +42,6 @@ pr_branch_head_sha=$(git rev-parse "${PR_BRANCH}")
 logIfVerbose "PR Branch Head= ${pr_branch_head_sha}"
 
 # Log the commits between the merge base and the merge instance's HEAD.
-git switch "${PR_BRANCH}"
 merge_base_sha=$(git merge-base "${merge_instance_branch_head_sha}" "${pr_branch_head_sha}")
 logIfVerbose "Merge Base= ${merge_base_sha}"
 merge_instance_depth=$(git rev-list "${merge_base_sha}".."${merge_instance_branch_head_sha}" | wc -l)

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -77,7 +77,7 @@ git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash
 java -jar bazel-diff.jar generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
-java -jar bazel-diff.jar get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}"
+java -jar bazel-diff.jar get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"
 num_impacted_targets=$(wc -l <"${impacted_targets_out}")
 echo "Computed ${num_impacted_targets} targets for sha ${pr_branch_head_sha}"
 


### PR DESCRIPTION
We cannot assume that Git clones are shallow, e.g. the user invokes `actions-checkout` with different options. `git fetch --unshallow` syntax claims to [support fetching complete clones](https://git-scm.com/docs/fetch-options#Documentation/fetch-options.txt---unshallow), but we ran into the following issue:

```
fatal: --unshallow on a complete repository does not make sense
```.

Fix by specifying the `--depth=` flag, which also claims to support both shallow and complete clones.
https://git-scm.com/docs/fetch-options#Documentation/fetch-options.txt---depthltdepthgt