### PR TITLE
feat: Timed Verbose Logging

### DIFF
--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -9,7 +9,8 @@ ifVerbose() {
 }
 
 logIfVerbose() {
-	ifVerbose echo "$@"
+	# trunk-ignore(shellcheck/SC2312): Always query date with each echo statement.
+	ifVerbose echo "$(date -u)" "$@"
 }
 
 # NOTE: We cannot assume that the checked out Git repo (e.g. via actions-checkout)


### PR DESCRIPTION
Add a timestamp to each logVerbose timestamp. Useful for getting a sense of hangs in performance. 