### PR TITLE
feat: Pipe Bazel Startup Options 

### DIFF
--- a/.github/workflows/compute_impacted_tests.yaml
+++ b/.github/workflows/compute_impacted_tests.yaml
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   tests:
     runs-on: ubuntu-latest
-    name: E2E Tests
+    name: Compute Impacted Targets Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/compute_impacted_tests.yaml
+++ b/.github/workflows/compute_impacted_tests.yaml
@@ -30,7 +30,7 @@ jobs:
           PR_BRANCH: do_not_delete/stable_test_branch
           VERBOSE: 1
           WORKSPACE_PATH: ./tests/simple_bazel_workspace
-          BAZEL_STARTUP_OPTIONS: --nobatch,--block_for_lock
+          BAZEL_STARTUP_OPTIONS: --host_jvm_args=-Xmx12G,--block_for_lock
 
       - name: Validate Impacted Targets Computation
         shell: bash

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -30,6 +30,7 @@ jobs:
           PR_BRANCH: do_not_delete/stable_test_branch
           VERBOSE: 1
           WORKSPACE_PATH: ./tests/simple_bazel_workspace
+          BAZEL_STARTUP_OPTIONS: --nobatch,--block_for_lock
 
       - name: Validate Impacted Targets Computation
         shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,12 @@ inputs:
   verbose:
     description: Whether to enable verbose logging. Defaults to false.
     required: false
+  bazel-startup-options:
+    description:
+      A comma separated list of startup options to pass to Bazel. See
+      https://bazel.build/reference/command-line-reference#startup-options for a complete list. If
+      unspecified, no startup options are specified.
+    required: false
 
 runs:
   using: composite
@@ -55,6 +61,7 @@ runs:
         PR_BRANCH: ${{ github.head_ref }}
         VERBOSE: ${{ inputs.verbose }}
         WORKSPACE_PATH: ${{ steps.prerequisites.outputs.workspace_path }}
+        BAZEL_STARTUP_OPTIONS: ${{ inputs.bazel-start-options }}
 
     - name: Upload Impacted Targets
       run: ${GITHUB_ACTION_PATH}/src/scripts/upload_impacted_targets.sh

--- a/action.yaml
+++ b/action.yaml
@@ -61,7 +61,7 @@ runs:
         PR_BRANCH: ${{ github.head_ref }}
         VERBOSE: ${{ inputs.verbose }}
         WORKSPACE_PATH: ${{ steps.prerequisites.outputs.workspace_path }}
-        BAZEL_STARTUP_OPTIONS: ${{ inputs.bazel-start-options }}
+        BAZEL_STARTUP_OPTIONS: ${{ inputs.bazel-startup-options }}
 
     - name: Upload Impacted Targets
       run: ${GITHUB_ACTION_PATH}/src/scripts/upload_impacted_targets.sh

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -32,7 +32,7 @@ logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
 bazelDiff() {
 	if [[ -n ${VERBOSE} ]]; then
-		java -jar bazel-diff.jar "$@"
+		java -jar bazel-diff.jar "$@" --verbose
 	else
 		java -jar bazel-diff.jar "$@"
 	fi

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -96,11 +96,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes "${bazel_startup_options}" --workspacePath="${WORKSPACE_PATH}" "${merge_instance_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes "${bazel_startup_options}" --workspacePath="${WORKSPACE_PATH}" "${merge_instance_with_pr_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -82,7 +82,7 @@ fi
 # Install the bazel-diff JAR. Avoid cloning the repo, as there will be conflicting WORKSPACES.
 curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
 java -jar bazel-diff.jar -V
-bazel --version
+bazel "${bazel_startup_options}" --version
 
 # Output Files
 merge_instance_branch_out=./${merge_instance_branch_head_sha}

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -36,8 +36,8 @@ fi
 
 bazelDiff() {
 	if [[ -n ${VERBOSE} ]]; then
-		echo "Running command" "java -jar bazel-diff.jar" "$@" "--verbose"
-		java -jar bazel-diff.jar "$@" --verbose
+		echo "Running command" "java -jar bazel-diff.jar" "--verbose" "$@"
+		java -jar bazel-diff.jar --verbose "$@" --verbose
 	else
 		java -jar bazel-diff.jar "$@"
 	fi

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -25,10 +25,11 @@ logIfVerbose() {
 
 # If specified, parse the Bazel startup options when generating hashes.
 logIfVerbose "Bazel startup options" "${BAZEL_STARTUP_OPTIONS}"
+bazel_startup_options=""
 if [[ -n ${VERBOSE} ]]; then
 	IFS=',' read -ra ADDR <<<"${BAZEL_STARTUP_OPTIONS}"
 	for i in "${ADDR[@]}"; do
-		echo "${i}"
+		bazel_startup_options="${bazel_start_options} -so=${i}"
 	done
 fi
 
@@ -93,11 +94,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_branch_out}"
+bazelDiff generate-hashes "${bazel_startup_options}" --workspacePath="${WORKSPACE_PATH}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_with_pr_branch_out}"
+bazelDiff generate-hashes "${bazel_startup_options}" --workspacePath="${WORKSPACE_PATH}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -28,14 +28,13 @@ bazel_startup_options=""
 if [[ -n ${VERBOSE} ]]; then
 	IFS=',' read -ra ADDR <<<"${BAZEL_STARTUP_OPTIONS}"
 	for i in "${ADDR[@]}"; do
-		bazel_startup_options="${bazel_startup_options} -so=${i}"
+		bazel_startup_options="-so=${i} ${bazel_startup_options} "
 	done
 fi
 logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
 bazelDiff() {
 	if [[ -n ${VERBOSE} ]]; then
-		echo "Running command" "java -jar bazel-diff.jar" "$@"
 		java -jar bazel-diff.jar "$@"
 	else
 		java -jar bazel-diff.jar "$@"
@@ -95,11 +94,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" -so=--nobatch "${merge_instance_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" -so=--no-batch "${merge_instance_with_pr_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -96,11 +96,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_branch_out}" "${bazel_startup_options}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_with_pr_branch_out}" "${bazel_startup_options}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -25,11 +25,8 @@ logIfVerbose() {
 
 # If specified, parse the Bazel startup options when generating hashes.
 bazel_startup_options=""
-if [[ -n ${VERBOSE} ]]; then
-	IFS=',' read -ra ADDR <<<"${BAZEL_STARTUP_OPTIONS}"
-	for i in "${ADDR[@]}"; do
-		bazel_startup_options="-so=${i} ${bazel_startup_options} "
-	done
+if [[ -n ${BAZEL_STARTUP_OPTIONS} ]]; then
+	bazel_startup_options=$(echo "${BAZEL_STARTUP_OPTIONS}" | tr ',' ' ')
 fi
 logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
@@ -94,11 +91,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -23,6 +23,15 @@ logIfVerbose() {
 	ifVerbose echo "$(date -u)" "$@"
 }
 
+# If specified, parse the Bazel startup options when generating hashes.
+logIfVerbose "Bazel startup options" "${BAZEL_STARTUP_OPTIONS}"
+if [[ -n ${VERBOSE} ]]; then
+	IFS=',' read -ra ADDR <<<"${BAZEL_STARTUP_OPTIONS}"
+	for i in "${ADDR[@]}"; do
+		echo "${i}"
+	done
+fi
+
 bazelDiff() {
 	if [[ -n ${VERBOSE} ]]; then
 		java -jar bazel-diff.jar "$@" --verbose
@@ -81,8 +90,6 @@ bazel --version
 merge_instance_branch_out=./${merge_instance_branch_head_sha}
 merge_instance_with_pr_branch_out=./${pr_branch_head_sha}_${merge_instance_branch_head_sha}
 impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
-
-# If specified, parse the Bazel startup options when generating hashes.
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -36,8 +36,8 @@ fi
 
 bazelDiff() {
 	if [[ -n ${VERBOSE} ]]; then
-		echo "Running command" "java -jar bazel-diff.jar" "--verbose" "$@"
-		java -jar bazel-diff.jar --verbose "$@" --verbose
+		echo "Running command" "java -jar bazel-diff.jar" "$@"
+		java -jar bazel-diff.jar "$@"
 	else
 		java -jar bazel-diff.jar "$@"
 	fi

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -24,6 +24,7 @@ logIfVerbose() {
 }
 
 # If specified, parse the Bazel startup options when generating hashes.
+# trunk-ignore(shellcheck/SC-2153): Correct spelling, passed in via env.
 logIfVerbose "Bazel startup options" "${BAZEL_STARTUP_OPTIONS}"
 bazel_startup_options=""
 if [[ -n ${VERBOSE} ]]; then

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -82,7 +82,7 @@ fi
 # Install the bazel-diff JAR. Avoid cloning the repo, as there will be conflicting WORKSPACES.
 curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
 java -jar bazel-diff.jar -V
-bazel "${bazel_startup_options}" --version
+bazel "${bazel_startup_options}" version
 
 # Output Files
 merge_instance_branch_out=./${merge_instance_branch_head_sha}

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -36,6 +36,7 @@ fi
 
 bazelDiff() {
 	if [[ -n ${VERBOSE} ]]; then
+		echo "Running command" "java -jar bazel-diff.jar" "$@" "--verbose"
 		java -jar bazel-diff.jar "$@" --verbose
 	else
 		java -jar bazel-diff.jar "$@"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -24,8 +24,6 @@ logIfVerbose() {
 }
 
 # If specified, parse the Bazel startup options when generating hashes.
-# trunk-ignore(shellcheck/SC2153)
-logIfVerbose "Bazel startup options" "${BAZEL_STARTUP_OPTIONS}"
 bazel_startup_options=""
 if [[ -n ${VERBOSE} ]]; then
 	IFS=',' read -ra ADDR <<<"${BAZEL_STARTUP_OPTIONS}"
@@ -33,6 +31,7 @@ if [[ -n ${VERBOSE} ]]; then
 		bazel_startup_options="${bazel_startup_options} -so=${i}"
 	done
 fi
+logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
 bazelDiff() {
 	if [[ -n ${VERBOSE} ]]; then
@@ -96,11 +95,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_branch_out}" "${bazel_startup_options}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${merge_instance_with_pr_branch_out}" "${bazel_startup_options}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -82,7 +82,8 @@ fi
 # Install the bazel-diff JAR. Avoid cloning the repo, as there will be conflicting WORKSPACES.
 curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
 java -jar bazel-diff.jar -V
-bazel "${bazel_startup_options}" version
+# trunk-ignore(shellcheck/SC2086)
+bazel ${bazel_startup_options} version
 
 # Output Files
 merge_instance_branch_out=./${merge_instance_branch_head_sha}

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -30,7 +30,7 @@ bazel_startup_options=""
 if [[ -n ${VERBOSE} ]]; then
 	IFS=',' read -ra ADDR <<<"${BAZEL_STARTUP_OPTIONS}"
 	for i in "${ADDR[@]}"; do
-		bazel_startup_options="${bazel_start_options} -so=${i}"
+		bazel_startup_options="${bazel_startup_options} -so=${i}"
 	done
 fi
 

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -24,7 +24,7 @@ logIfVerbose() {
 }
 
 # If specified, parse the Bazel startup options when generating hashes.
-# trunk-ignore(shellcheck/SC-2153): Correct spelling, passed in via env.
+# trunk-ignore(shellcheck/SC2153)
 logIfVerbose "Bazel startup options" "${BAZEL_STARTUP_OPTIONS}"
 bazel_startup_options=""
 if [[ -n ${VERBOSE} ]]; then

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -95,11 +95,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" -so=--nobatch "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
+bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" -so=--no-batch "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"


### PR DESCRIPTION
Support plumbing Bazel startup options into `bazel-diff`.

Also: rename the e2e tests --> compute_impacted_targets tests, they aren't e2e.

Closes https://linear.app/trunk/issue/TRUNK-8646/plumb-bazel-startup-options-into-merge-action