### PR TITLE
feat: Migrate to `bazel-differ`

### DIFF
--- a/.github/workflows/compute_impacted_tests.yaml
+++ b/.github/workflows/compute_impacted_tests.yaml
@@ -25,6 +25,7 @@ jobs:
           VERBOSE: 1
           WORKSPACE_PATH: ./tests/simple_bazel_workspace
           BAZEL_STARTUP_OPTIONS: --host_jvm_args=-Xmx12G,--block_for_lock,--client_debug
+          ARCH: x86_64
 
       - name: Validate Impacted Targets Computation
         shell: bash

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ define your own suite of impacted targets using glob-based targets.
 
 ### Under the hood: Bazel
 
-We use Tinder's [bazel-diff](https://github.com/Tinder/bazel-diff) tool to compute the impacted
-targets of a particular PR. The tool computes a mapping of package --> hash at the source and dest
-shas, then reports any packages which have a differing hash.
+We use [bazel-differ](https://github.com/ewhauser/bazel-differ), a port of Tinder's
+[bazel-diff](https://github.com/tinder/bazel-diff) to compute the impacted targets of a particular
+PR. The tool computes a mapping of package --> hash at the source and dest shas, then reports any
+packages which have a differing hash.

--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,7 @@ runs:
         PR_BRANCH: ${{ github.head_ref }}
         VERBOSE: ${{ inputs.verbose }}
         WORKSPACE_PATH: ${{ steps.prerequisites.outputs.workspace_path }}
+        ARCH: ${{ steps.prerequisites.outputs.arch }}
         BAZEL_STARTUP_OPTIONS: ${{ inputs.bazel-startup-options }}
 
     - name: Upload Impacted Targets

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -85,11 +85,6 @@ if [[ -n ${VERBOSE} ]]; then
 	git log -n "${pr_depth}" --oneline
 fi
 
-# Install the bazel-diff JAR. Avoid cloning the repo, as there will be conflicting WORKSPACES.
-curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
-_java -jar bazel-diff.jar -V
-bazel version # Does not require running with startup options.
-
 # Output Files
 merge_instance_branch_out=./${merge_instance_branch_head_sha}
 merge_instance_with_pr_branch_out=./${pr_branch_head_sha}_${merge_instance_branch_head_sha}

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -92,11 +92,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiffer generate-hashes --workspacePath="${WORKSPACE_PATH}" "--bazelStartupOptions=${bazel_startup_options}" --finalHashes="${merge_instance_branch_out}"
+bazelDiffer generate-hashes --workspacePath="${WORKSPACE_PATH}" "--bazelStartupOptions=${bazel_startup_options}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiffer generate-hashes --workspacePath="${WORKSPACE_PATH}" "--bazelStartupOptions=${bazel_startup_options}" --finalHashes="${merge_instance_with_pr_branch_out}"
+bazelDiffer generate-hashes --workspacePath="${WORKSPACE_PATH}" "--bazelStartupOptions=${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiffer diff --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -33,7 +33,7 @@ logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
 # TODO: Grab latest.
 # TODO: Grab version based off arch.
-curl --retry 5 -Lo bazel-differ https://github.com/ewhauser/bazel-differ/releases/download/v0.0.7/bazel-differ-linux-arm64
+curl --retry 5 -Lo bazel-differ https://github.com/ewhauser/bazel-differ/releases/download/v0.0.7/bazel-differ-linux-x86_64
 chmod +x ./bazel-differ
 
 bazelDiffer() {

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -38,9 +38,9 @@ chmod +x ./bazel-differ
 
 bazelDiffer() {
 	if [[ -n ${VERBOSE} ]]; then
-		bazel-differ "$@" --verbose
+		./bazel-differ "$@" --verbose
 	else
-		bazel-differ "$@"
+		./bazel-differ "$@"
 	fi
 }
 

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -13,6 +13,11 @@ if [[ -z ${WORKSPACE_PATH} ]]; then
 	exit 2
 fi
 
+if [[ -z ${ARCH} ]]; then
+	echo "Missing architecture"
+	exit 2
+fi
+
 ifVerbose() {
 	if [[ -n ${VERBOSE} ]]; then
 		"$@"
@@ -31,9 +36,7 @@ if [[ -n ${BAZEL_STARTUP_OPTIONS} ]]; then
 fi
 logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
-# TODO: Grab latest.
-# TODO: Grab version based off arch.
-curl --retry 5 -Lo bazel-differ https://github.com/ewhauser/bazel-differ/releases/download/v0.0.7/bazel-differ-linux-x86_64
+curl --retry 5 -Lo bazel-differ "https://github.com/ewhauser/bazel-differ/releases/latest/download/bazel-differ-linux-${ARCH}"
 chmod +x ./bazel-differ
 
 bazelDiffer() {

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -18,15 +18,7 @@ if [[ -z ${workspace_path} ]]; then
 	workspace_path=$(pwd)
 fi
 
-arch=""
-if (uname -a | grep arm64); then
-	arch="arm64"
-elif (uname -a | grep x86_64); then
-	arch="x86_64"
-else
-	echo "Could not determine architecture"
-	exit 2
-fi
+arch=$(uname -m)
 
 # Outputs
 # trunk-ignore(shellcheck/SC2129)

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -18,6 +18,18 @@ if [[ -z ${workspace_path} ]]; then
 	workspace_path=$(pwd)
 fi
 
+arch=""
+if (uname -a | grep arm64); then
+	arch="arm64"
+elif (uname -a | grep x86_64); then
+	arch="x86_64"
+else
+	echo "Could not determine architecture"
+	exit 2
+fi
+
 # Outputs
+# trunk-ignore(shellcheck/SC2129)
 echo "merge_instance_branch=${merge_instance_branch}" >>"${GITHUB_OUTPUT}"
 echo "workspace_path=${workspace_path}" >>"${GITHUB_OUTPUT}"
+echo "arch=${arch}" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
`bazel-differ` is a drop-in replacement of Tinder's bazel-diff. The former requires less installation and setup, so we suspect it'll be more flexible by use in customer's CI.

Before releasing to production, we should let this bake in staging for a little bit.

Thanks to @pat for the suggestions.