### PR TITLE
Revert "feat: Migrate to `bazel-differ`"

### DIFF
--- a/.github/workflows/compute_impacted_tests.yaml
+++ b/.github/workflows/compute_impacted_tests.yaml
@@ -25,7 +25,6 @@ jobs:
           VERBOSE: 1
           WORKSPACE_PATH: ./tests/simple_bazel_workspace
           BAZEL_STARTUP_OPTIONS: --host_jvm_args=-Xmx12G,--block_for_lock,--client_debug
-          ARCH: x86_64
 
       - name: Validate Impacted Targets Computation
         shell: bash

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ define your own suite of impacted targets using glob-based targets.
 
 ### Under the hood: Bazel
 
-We use [bazel-differ](https://github.com/ewhauser/bazel-differ), a port of Tinder's
-[bazel-diff](https://github.com/tinder/bazel-diff) to compute the impacted targets of a particular
-PR. The tool computes a mapping of package --> hash at the source and dest shas, then reports any
-packages which have a differing hash.
+We use Tinder's [bazel-diff](https://github.com/Tinder/bazel-diff) tool to compute the impacted
+targets of a particular PR. The tool computes a mapping of package --> hash at the source and dest
+shas, then reports any packages which have a differing hash.

--- a/action.yaml
+++ b/action.yaml
@@ -55,7 +55,6 @@ runs:
         PR_BRANCH: ${{ github.head_ref }}
         VERBOSE: ${{ inputs.verbose }}
         WORKSPACE_PATH: ${{ steps.prerequisites.outputs.workspace_path }}
-        ARCH: ${{ steps.prerequisites.outputs.arch }}
         BAZEL_STARTUP_OPTIONS: ${{ inputs.bazel-startup-options }}
 
     - name: Upload Impacted Targets

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -18,10 +18,6 @@ if [[ -z ${workspace_path} ]]; then
 	workspace_path=$(pwd)
 fi
 
-arch=$(uname -m)
-
 # Outputs
-# trunk-ignore(shellcheck/SC2129)
 echo "merge_instance_branch=${merge_instance_branch}" >>"${GITHUB_OUTPUT}"
 echo "workspace_path=${workspace_path}" >>"${GITHUB_OUTPUT}"
-echo "arch=${arch}" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
Reverts trunk-io/merge-action#27

@det suspects that there's a precision loss in impacted targets in bazel-differ vs. bazel-diff. While we investigate alternative solutions, switch back to using bazel-diff.