### PR TITLE
feat: Support a Bazel Path

### DIFF
--- a/.github/workflows/compute_impacted_tests.yaml
+++ b/.github/workflows/compute_impacted_tests.yaml
@@ -25,6 +25,7 @@ jobs:
           VERBOSE: 1
           WORKSPACE_PATH: ./tests/simple_bazel_workspace
           BAZEL_STARTUP_OPTIONS: --host_jvm_args=-Xmx12G,--block_for_lock,--client_debug
+          BAZEL_PATH: bazel
 
       - name: Validate Impacted Targets Computation
         shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,7 @@ runs:
   using: composite
   steps:
     - name: Setup Bazel
+      if: ${{ inputs.bazel-path }} # If specified, use the provided Bazel and skip installation.
       # trunk-ignore(semgrep): Trust third-party `bazelbuild` GH Action
       uses: bazelbuild/setup-bazelisk@v2
 

--- a/action.yaml
+++ b/action.yaml
@@ -33,7 +33,7 @@ runs:
   using: composite
   steps:
     - name: Setup Bazel
-      if: ${{ inputs.bazel-path == '' }} # If unspecified, use the provided Bazel and skip installation.
+      if: ${{ inputs.bazel-path == '' }}
       # trunk-ignore(semgrep): Trust third-party `bazelbuild` GH Action
       uses: bazelbuild/setup-bazelisk@v2
 

--- a/action.yaml
+++ b/action.yaml
@@ -33,7 +33,7 @@ runs:
   using: composite
   steps:
     - name: Setup Bazel
-      if: ${{ ! inputs.bazel-path }} # If specified, use the provided Bazel and skip installation.
+      if: ${{ inputs.bazel-path != '' }} # If specified, use the provided Bazel and skip installation.
       # trunk-ignore(semgrep): Trust third-party `bazelbuild` GH Action
       uses: bazelbuild/setup-bazelisk@v2
 

--- a/action.yaml
+++ b/action.yaml
@@ -33,7 +33,7 @@ runs:
   using: composite
   steps:
     - name: Setup Bazel
-      if: ${{ inputs.bazel-path != '' }} # If specified, use the provided Bazel and skip installation.
+      if: ${{ inputs.bazel-path == '' }} # If unspecified, use the provided Bazel and skip installation.
       # trunk-ignore(semgrep): Trust third-party `bazelbuild` GH Action
       uses: bazelbuild/setup-bazelisk@v2
 

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,9 @@ inputs:
       https://bazel.build/reference/command-line-reference#startup-options for a complete list. If
       unspecified, no startup options are specified.
     required: false
+  bazel-path:
+    description: A path to the Bazel executable. Defaults to PATH.
+    required: false
 
 runs:
   using: composite
@@ -55,6 +58,7 @@ runs:
         PR_BRANCH: ${{ github.head_ref }}
         VERBOSE: ${{ inputs.verbose }}
         WORKSPACE_PATH: ${{ steps.prerequisites.outputs.workspace_path }}
+        BAZEL_PATH: ${{ inputs.bazel-path }}
         BAZEL_STARTUP_OPTIONS: ${{ inputs.bazel-startup-options }}
 
     - name: Upload Impacted Targets

--- a/action.yaml
+++ b/action.yaml
@@ -33,7 +33,7 @@ runs:
   using: composite
   steps:
     - name: Setup Bazel
-      if: ${{ inputs.bazel-path }} # If specified, use the provided Bazel and skip installation.
+      if: ${{ ! inputs.bazel-path }} # If specified, use the provided Bazel and skip installation.
       # trunk-ignore(semgrep): Trust third-party `bazelbuild` GH Action
       uses: bazelbuild/setup-bazelisk@v2
 

--- a/action.yaml
+++ b/action.yaml
@@ -28,19 +28,11 @@ inputs:
   bazel-path:
     description: A path to the Bazel executable. Defaults to PATH.
     required: false
+    default: bazel
 
 runs:
   using: composite
   steps:
-    - name: Setup Bazel
-      if: ${{ inputs.bazel-path == '' }}
-      # trunk-ignore(semgrep): Trust third-party `bazelbuild` GH Action
-      uses: bazelbuild/setup-bazelisk@v2
-
-    - name: Setup jq
-      # trunk-ignore(semgrep): Trust third-party action to install JQ. Source code: https://github.com/dcarbone/install-jq-action/
-      uses: dcarbone/install-jq-action@v1.0.1
-
     - name: Prerequisites
       id: prerequisites
       run: ${GITHUB_ACTION_PATH}/src/scripts/prerequisites.sh
@@ -49,6 +41,16 @@ runs:
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
         WORKSPACE_PATH: ${{ inputs.bazel-workspace-path }}
+        BAZEL_PATH: ${{ inputs.bazel-path }}
+
+    - name: Install Bazel in PATH
+      if: ${{ steps.prerequisites.outputs.requires_default_bazel_installation == 'true' }}
+      # trunk-ignore(semgrep): Trust third-party `bazelbuild` GH Action
+      uses: bazelbuild/setup-bazelisk@v2
+
+    - name: Setup jq
+      # trunk-ignore(semgrep): Trust third-party action to install JQ. Source code: https://github.com/dcarbone/install-jq-action/
+      uses: dcarbone/install-jq-action@v1.0.1
 
     - name: Compute Impacted Targets
       id: compute-impacted-targets

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -31,13 +31,13 @@ if [[ -n ${BAZEL_STARTUP_OPTIONS} ]]; then
 fi
 logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
-_bazel() {
-	# trunk-ignore(shellcheck/SC2153): Passed in as env variable
-	bazel_path="${BAZEL_PATH}"
-	if [[ -z ${bazel_path} ]]; then
-		bazel_path=$(command -v bazel)
-	fi
+# trunk-ignore(shellcheck/SC2153): Passed in as env variable
+bazel_path="${BAZEL_PATH}"
+if [[ -z ${bazel_path} ]]; then
+	bazel_path=$(command -v bazel)
+fi
 
+_bazel() {
 	# trunk-ignore(shellcheck)
 	${bazel_path} ${bazel_startup_options} "$@"
 }
@@ -106,11 +106,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_branch_out}"
+bazelDiff generate-hashes --bazelPath="${bazel_path}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
+bazelDiff generate-hashes --bazelPath="${bazel_path}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -32,8 +32,14 @@ fi
 logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
 _bazel() {
+	# trunk-ignore(shellcheck/SC2153): Passed in as env variable
+	bazel_path="${BAZEL_PATH}"
+	if [[ -z ${bazel_path} ]]; then
+		bazel_path=$(command -v bazel)
+	fi
+
 	# trunk-ignore(shellcheck)
-	bazel ${bazel_startup_options} "$@"
+	${bazel_path} ${bazel_startup_options} "$@"
 }
 
 # trunk-ignore(shellcheck)

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -31,9 +31,10 @@ if [[ -n ${BAZEL_STARTUP_OPTIONS} ]]; then
 fi
 logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
-# trunk-ignore(shellcheck/SC2153): Passed in as env variable
-bazel_path="${BAZEL_PATH}"
-if [[ -z ${bazel_path} ]]; then
+bazel_path=""
+if [[ -n ${BAZEL_PATH} ]]; then
+	bazel_path="${BAZEL_PATH}"
+else
 	bazel_path=$(command -v bazel)
 fi
 
@@ -97,7 +98,7 @@ fi
 # Install the bazel-diff JAR. Avoid cloning the repo, as there will be conflicting WORKSPACES.
 curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
 _java -jar bazel-diff.jar -V
-bazel version # Does not require running with startup options.
+_bazel version # Does not require running with startup options.
 
 # Output Files
 merge_instance_branch_out=./${merge_instance_branch_head_sha}

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -31,7 +31,7 @@ if [[ -n ${BAZEL_STARTUP_OPTIONS} ]]; then
 fi
 logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
-bazel_path="${BAZELPATH:-$(command -v bazel)}"
+bazel_path="${BAZEL_PATH:-$(command -v bazel)}"
 
 _bazel() {
 	# trunk-ignore(shellcheck)

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -31,12 +31,7 @@ if [[ -n ${BAZEL_STARTUP_OPTIONS} ]]; then
 fi
 logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
-bazel_path=""
-if [[ -n ${BAZEL_PATH} ]]; then
-	bazel_path="${BAZEL_PATH}"
-else
-	bazel_path=$(command -v bazel)
-fi
+bazel_path="${BAZELPATH:-$(command -v bazel)}"
 
 _bazel() {
 	# trunk-ignore(shellcheck)

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -31,11 +31,9 @@ if [[ -n ${BAZEL_STARTUP_OPTIONS} ]]; then
 fi
 logIfVerbose "Bazel startup options" "${bazel_startup_options}"
 
-bazel_path="${BAZEL_PATH:-$(command -v bazel)}"
-
 _bazel() {
 	# trunk-ignore(shellcheck)
-	${bazel_path} ${bazel_startup_options} "$@"
+	${BAZEL_PATH} ${bazel_startup_options} "$@"
 }
 
 # trunk-ignore(shellcheck)
@@ -102,11 +100,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes --bazelPath="${bazel_path}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_branch_out}"
+bazelDiff generate-hashes --bazelPath="${BAZEL_PATH}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes --bazelPath="${bazel_path}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
+bazelDiff generate-hashes --bazelPath="${BAZEL_PATH}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -20,10 +20,12 @@ fi
 
 requires_default_bazel_installation="false"
 if [[ ${BAZEL_PATH} == "bazel" ]]; then
-	# DO NOT LAND
-	command -v bazel
 	if ! command -v bazel; then
+		echo "requires bazel installation"
 		requires_default_bazel_installation="true"
+	else
+		echo "does not require bazel installation"
+		# DO NOT LAND
 	fi
 fi
 

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -20,6 +20,8 @@ fi
 
 requires_default_bazel_installation="false"
 if [[ ${BAZEL_PATH} == "bazel" ]]; then
+	# DO NOT LAND
+	command -v bazel
 	if ! command -v bazel; then
 		requires_default_bazel_installation="true"
 	fi

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -18,6 +18,15 @@ if [[ -z ${workspace_path} ]]; then
 	workspace_path=$(pwd)
 fi
 
+requires_default_bazel_installation="false"
+if [[ ${BAZEL_PATH} == "bazel" ]]; then
+	if ! command -v bazel; then
+		requires_default_bazel_installation="true"
+	fi
+fi
+
 # Outputs
+# trunk-ignore(shellcheck/SC2129)
 echo "merge_instance_branch=${merge_instance_branch}" >>"${GITHUB_OUTPUT}"
 echo "workspace_path=${workspace_path}" >>"${GITHUB_OUTPUT}"
+echo "requires_default_bazel_installation=${requires_default_bazel_installation}" >>"${GITHUB_OUTPUT}"

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -21,11 +21,7 @@ fi
 requires_default_bazel_installation="false"
 if [[ ${BAZEL_PATH} == "bazel" ]]; then
 	if ! command -v bazel; then
-		echo "requires bazel installation"
 		requires_default_bazel_installation="true"
-	else
-		echo "does not require bazel installation"
-		# DO NOT LAND
 	fi
 fi
 


### PR DESCRIPTION
- Allow users to pass in a path to the Bazel path executable. Useful for custom installations of Bazel.
- Only install Bazel to the PATH if the expected bazel-path is `bazel`, but no bazel exists. If a user provides a custom bazel-path, we assume the executable exists. Similarly, if bazel already exists, no need to install.
