### PR TITLE
cleanup: Deprecate `bazel-workspace-path`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,11 +11,6 @@ inputs:
       The Merge Instance's target branch. If unspecified, defaults to the repository's default
       branch.
     required: false
-  bazel-workspace-path:
-    description:
-      The path to the bazel WORKSPACE, relative to the root of the git repository. If unspecified,
-      defaults to the root of the repository.
-    required: false
   verbose:
     description: Whether to enable verbose logging. Defaults to false.
     required: false
@@ -40,7 +35,6 @@ runs:
       env:
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
-        WORKSPACE_PATH: ${{ inputs.bazel-workspace-path }}
         BAZEL_PATH: ${{ inputs.bazel-path }}
 
     - name: Install Bazel in PATH
@@ -60,7 +54,6 @@ runs:
         MERGE_INSTANCE_BRANCH: ${{ steps.prerequisites.outputs.merge_instance_branch }}
         PR_BRANCH: ${{ github.head_ref }}
         VERBOSE: ${{ inputs.verbose }}
-        WORKSPACE_PATH: ${{ steps.prerequisites.outputs.workspace_path }}
         BAZEL_PATH: ${{ inputs.bazel-path }}
         BAZEL_STARTUP_OPTIONS: ${{ inputs.bazel-startup-options }}
 

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -8,10 +8,7 @@ if [[ (-z ${MERGE_INSTANCE_BRANCH}) || (-z ${PR_BRANCH}) ]]; then
 	exit 2
 fi
 
-if [[ -z ${WORKSPACE_PATH} ]]; then
-	echo "Missing workspace path"
-	exit 2
-fi
+workspace_path=$(pwd)
 
 ifVerbose() {
 	if [[ -n ${VERBOSE} ]]; then
@@ -100,11 +97,11 @@ impacted_targets_out=./impacted_targets_${pr_branch_head_sha}
 
 # Generate Hashes for the Merge Instance Branch
 git switch "${MERGE_INSTANCE_BRANCH}"
-bazelDiff generate-hashes --bazelPath="${BAZEL_PATH}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_branch_out}"
+bazelDiff generate-hashes --bazelPath="${BAZEL_PATH}" --workspacePath="${workspace_path}" "-so=${bazel_startup_options}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
 git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
-bazelDiff generate-hashes --bazelPath="${BAZEL_PATH}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
+bazelDiff generate-hashes --bazelPath="${BAZEL_PATH}" --workspacePath="${workspace_path}" "-so=${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets
 bazelDiff get-impacted-targets --startingHashes="${merge_instance_branch_out}" --finalHashes="${merge_instance_with_pr_branch_out}" --output="${impacted_targets_out}"

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -12,12 +12,6 @@ if [[ -z ${merge_instance_branch} ]]; then
 	exit 2
 fi
 
-# trunk-ignore(shellcheck/SC2153): Passed in as env variable
-workspace_path="${WORKSPACE_PATH}"
-if [[ -z ${workspace_path} ]]; then
-	workspace_path=$(pwd)
-fi
-
 requires_default_bazel_installation="false"
 if [[ ${BAZEL_PATH} == "bazel" ]]; then
 	if ! command -v bazel; then
@@ -26,7 +20,5 @@ if [[ ${BAZEL_PATH} == "bazel" ]]; then
 fi
 
 # Outputs
-# trunk-ignore(shellcheck/SC2129)
 echo "merge_instance_branch=${merge_instance_branch}" >>"${GITHUB_OUTPUT}"
-echo "workspace_path=${workspace_path}" >>"${GITHUB_OUTPUT}"
 echo "requires_default_bazel_installation=${requires_default_bazel_installation}" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
We have intentions for this repository to only be applicable to Bazel workspaces. Assume that the root of the repo contains the WORKSPACE file -- our current implementation doesn't play nicely with Bazel invocations in non-WORKSPACE roots.