### PR TITLE
Handle Uploading Impacted Targets From Forked PRs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,7 @@ runs:
       env:
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
-        PR_BRANCH: ${{ github.head_ref }}
+        PR_BRANCH: ${{ github.event.pull_request.head.sha }}
         WORKSPACE_PATH: ${{ inputs.bazel-workspace-path }}
         BAZEL_PATH: ${{ inputs.bazel-path }}
         IMPACTS_FILTERS_CHANGES: ${{ steps.detect-changed-paths.outputs.changes }}

--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,7 @@ runs:
       env:
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
-        PR_BRANCH: ${{ github.event.pull_request.head.sha }}
+        PR_BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         WORKSPACE_PATH: ${{ inputs.bazel-workspace-path }}
         BAZEL_PATH: ${{ inputs.bazel-path }}
         IMPACTS_FILTERS_CHANGES: ${{ steps.detect-changed-paths.outputs.changes }}
@@ -80,8 +80,7 @@ runs:
         MERGE_INSTANCE_BRANCH: ${{ steps.prerequisites.outputs.merge_instance_branch }}
         MERGE_INSTANCE_BRANCH_HEAD_SHA:
           ${{ steps.prerequisites.outputs.merge_instance_branch_head_sha }}
-        PR_BRANCH: ${{ steps.prerequisites.outputs.pr_branch }}
-        PR_BRANCH_HEAD_SHA: ${{ steps.prerequisites.outputs.pr_branch_head_sha }}
+        PR_BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         VERBOSE: ${{ inputs.verbose }}
         WORKSPACE_PATH: ${{ steps.prerequisites.outputs.workspace_path }}
         BAZEL_PATH: ${{ inputs.bazel-path }}
@@ -98,6 +97,6 @@ runs:
         IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         TARGET_BRANCH: ${{ steps.prerequisites.outputs.merge_instance_branch }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
-        PR_SHA: ${{ steps.prerequisites.outputs.pr_branch_head_sha }}
+        PR_BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         IMPACTED_TARGETS_FILE: ${{ steps.compute-impacted-targets.outputs.impacted_targets_out }}
         IMPACTS_ALL_DETECTED: ${{ steps.prerequisites.outputs.impacts_all_detected }}

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -53,15 +53,6 @@ bazelDiff() {
 	fi
 }
 
-# NOTE: We cannot assume that the checked out Git repo (e.g. via actions-checkout)
-# was a shallow vs a complete clone. The `--depth` options deepens the commit history
-# in both clone modes: https://git-scm.com/docs/fetch-options#Documentation/fetch-options.txt---depthltdepthgt
-fetchRemoteGitHistory() {
-	logIfVerbose "Fetching" "$@" "..."
-	git fetch --quiet --depth=2147483647 origin "$@"
-	logIfVerbose "...done!"
-}
-
 ## Verbose logging for the Merge Instance and PR branch.
 if [[ -n ${VERBOSE} ]]; then
 	# Find the merge base of the two branches
@@ -72,14 +63,14 @@ if [[ -n ${VERBOSE} ]]; then
 	merge_instance_depth=$(git rev-list "${merge_base_sha}".."${MERGE_INSTANCE_BRANCH_HEAD_SHA}" | wc -l)
 	echo "Merge Instance Depth= ${merge_instance_depth}"
 
-	git switch "${MERGE_INSTANCE_BRANCH}"
+	git checkout "${MERGE_INSTANCE_BRANCH}"
 	git log -n "${merge_instance_depth}" --oneline
 
 	# Find the number of commits between the merge base and the PR's HEAD
 	pr_depth=$(git rev-list "${merge_base_sha}".."${PR_BRANCH_HEAD_SHA}" | wc -l)
 	echo "PR Depth= ${pr_depth}"
 
-	git switch "${PR_BRANCH}"
+	git checkout "${PR_BRANCH}"
 	git log -n "${pr_depth}" --oneline
 fi
 

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+set -x
 shopt -s expand_aliases
 
 if [[ (-z ${MERGE_INSTANCE_BRANCH}) || (-z ${PR_BRANCH}) ]]; then

--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-set -x
 shopt -s expand_aliases
 
-if [[ (-z ${MERGE_INSTANCE_BRANCH}) || (-z ${PR_BRANCH}) ]]; then
+if [[ -z ${MERGE_INSTANCE_BRANCH} ]]; then
 	echo "Missing branch"
 	exit 2
 fi
@@ -70,7 +69,7 @@ if [[ -n ${VERBOSE} ]]; then
 	pr_depth=$(git rev-list "${merge_base_sha}".."${PR_BRANCH_HEAD_SHA}" | wc -l)
 	echo "PR Depth= ${pr_depth}"
 
-	git checkout "${PR_BRANCH}"
+	git checkout "${PR_BRANCH_HEAD_SHA}"
 	git log -n "${pr_depth}" --oneline
 fi
 
@@ -89,7 +88,7 @@ git switch "${MERGE_INSTANCE_BRANCH}"
 bazelDiff generate-hashes --bazelPath="${BAZEL_PATH}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_branch_out}"
 
 # Generate Hashes for the Merge Instance Branch + PR Branch
-git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH}"
+git -c "user.name=Trunk Actions" -c "user.email=actions@trunk.io" merge --squash "${PR_BRANCH_HEAD_SHA}"
 bazelDiff generate-hashes --bazelPath="${BAZEL_PATH}" --workspacePath="${WORKSPACE_PATH}" "-so=${bazel_startup_options}" "${merge_instance_with_pr_branch_out}"
 
 # Compute impacted targets

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+set -x
 
 # NOTE: We cannot assume that the checked out Git repo (e.g. via actions-checkout)
 # was a shallow vs a complete clone. The `--depth` options deepens the commit history
@@ -47,10 +48,7 @@ fi
 fetchRemoteGitHistory "${merge_instance_branch}"
 fetchRemoteGitHistory "${pr_branch}"
 
-git switch "${merge_instance_branch}"
-merge_instance_branch_head_sha=$(git rev-parse "${merge_instance_branch}")
-
-git switch "${pr_branch}"
+merge_instance_branch_head_sha=$(git rev-parse "origin/${merge_instance_branch}")
 pr_branch_head_sha=$(git rev-parse "${pr_branch}")
 
 echo "Identified changes: " "${impacts_all_detected}"

--- a/src/scripts/upload_impacted_targets.sh
+++ b/src/scripts/upload_impacted_targets.sh
@@ -86,7 +86,7 @@ fi
 RESPONSE_BODY_FILE="./response.txt"
 
 HTTP_STATUS_CODE=$(
-	curl -s -o "${RESPONSE_BODY_FILE}" -w '%{http_code}' -X POST \
+	curl -v -s -o "${RESPONSE_BODY_FILE}" -w '%{http_code}' -X POST \
 		-H "Content-Type: application/json" -H "x-api-token:${API_TOKEN-}" -H "x-forked-workflow-run-id:${RUN_ID-}" \
 		-d "@${POST_BODY}" \
 		"${API_URL}"
@@ -115,8 +115,7 @@ fi
 echo "${COMMENT_TEXT}"
 
 if [[ ${HTTP_STATUS_CODE} != 200 ]]; then
-	echo "Response Body:"
-	cat "${RESPONSE_BODY_FILE}"
+	echo "Response Message - " | cat "${RESPONSE_BODY_FILE}"
 fi
 
 exit "${EXIT_CODE}"

--- a/src/scripts/upload_impacted_targets.sh
+++ b/src/scripts/upload_impacted_targets.sh
@@ -87,7 +87,7 @@ RESPONSE_BODY_FILE="./response.txt"
 
 HTTP_STATUS_CODE=$(
 	curl -v -s -o "${RESPONSE_BODY_FILE}" -w '%{http_code}' -X POST \
-		-H "Content-Type: application/json" -H "x-api-token:${API_TOKEN-}" -H "x-forked-workflow-run-id:${RUN_ID-}" \
+		-H "Content-Type: application/json" -H "x-api-token:${API_TOKEN-}" -H "x-forked-worfklow-run-id:${RUN_ID-}" \
 		-d "@${POST_BODY}" \
 		"${API_URL}"
 )
@@ -115,7 +115,8 @@ fi
 echo "${COMMENT_TEXT}"
 
 if [[ ${HTTP_STATUS_CODE} != 200 ]]; then
-	echo "Response Message - " | cat "${RESPONSE_BODY_FILE}"
+	echo "Response Body:"
+	cat "${RESPONSE_BODY_FILE}"
 fi
 
 exit "${EXIT_CODE}"

--- a/src/scripts/upload_impacted_targets.sh
+++ b/src/scripts/upload_impacted_targets.sh
@@ -83,8 +83,10 @@ else
 	num_impacted_targets=$(wc -l <"${IMPACTED_TARGETS_FILE}")
 fi
 
+RESPONSE_BODY_FILE="./response.txt"
+
 HTTP_STATUS_CODE=$(
-	curl -s -o /dev/null -w '%{http_code}' -X POST \
+	curl -s -o "${RESPONSE_BODY_FILE}" -w '%{http_code}' -X POST \
 		-H "Content-Type: application/json" -H "x-api-token:${API_TOKEN-}" -H "x-forked-workflow-run-id:${RUN_ID-}" \
 		-d "@${POST_BODY}" \
 		"${API_URL}"
@@ -111,4 +113,10 @@ else
 fi
 
 echo "${COMMENT_TEXT}"
+
+if [[ ${HTTP_STATUS_CODE} != 200 ]]; then
+	echo "Response Body:"
+	cat "${RESPONSE_BODY_FILE}"
+fi
+
 exit "${EXIT_CODE}"

--- a/src/scripts/upload_impacted_targets.sh
+++ b/src/scripts/upload_impacted_targets.sh
@@ -23,7 +23,7 @@ fi
 REPO_OWNER=$(echo "${REPOSITORY}" | cut -d "/" -f 1)
 REPO_NAME=$(echo "${REPOSITORY}" | cut -d "/" -f 2)
 
-if [[ (-z ${PR_NUMBER}) || (-z ${PR_SHA}) ]]; then
+if [[ (-z ${PR_NUMBER}) || (-z ${PR_BRANCH_HEAD_SHA}) ]]; then
 	echo "Missing PR params"
 	exit 2
 fi
@@ -44,7 +44,7 @@ REPO_BODY=$(
 PR_BODY=$(
 	jq --null-input \
 		--arg number "${PR_NUMBER}" \
-		--arg sha "${PR_SHA}" \
+		--arg sha "${PR_BRANCH_HEAD_SHA}" \
 		'{ "number": $number, "sha": $sha }'
 )
 
@@ -86,8 +86,8 @@ fi
 RESPONSE_BODY_FILE="./response.txt"
 
 HTTP_STATUS_CODE=$(
-	curl -v -s -o "${RESPONSE_BODY_FILE}" -w '%{http_code}' -X POST \
-		-H "Content-Type: application/json" -H "x-api-token:${API_TOKEN-}" -H "x-forked-worfklow-run-id:${RUN_ID-}" \
+	curl -s -o "${RESPONSE_BODY_FILE}" -w '%{http_code}' -X POST \
+		-H "Content-Type: application/json" -H "x-api-token:${API_TOKEN-}" -H "x-forked-workflow-run-id:${RUN_ID-}" \
 		-d "@${POST_BODY}" \
 		"${API_URL}"
 )
@@ -95,10 +95,10 @@ HTTP_STATUS_CODE=$(
 EXIT_CODE=0
 COMMENT_TEXT=""
 if [[ ${HTTP_STATUS_CODE} == 200 ]]; then
-	COMMENT_TEXT="✨ Uploaded ${num_impacted_targets} impacted targets for ${PR_NUMBER} @ ${PR_SHA}"
+	COMMENT_TEXT="✨ Uploaded ${num_impacted_targets} impacted targets for ${PR_NUMBER} @ ${PR_BRANCH_HEAD_SHA}"
 else
 	EXIT_CODE=1
-	COMMENT_TEXT="❌ Unable to upload impacted targets. Encountered ${HTTP_STATUS_CODE} @ ${PR_SHA}. Please contact us at slack.trunk.io."
+	COMMENT_TEXT="❌ Unable to upload impacted targets. Encountered ${HTTP_STATUS_CODE} @ ${PR_BRANCH_HEAD_SHA}. Please contact us at slack.trunk.io."
 
 	# Dependabot doesn't have access to GitHub action Secrets.
 	# On authn failure, prompt the user to update their token.

--- a/tests/upload.test.ts
+++ b/tests/upload.test.ts
@@ -10,6 +10,7 @@ import { describe, beforeEach, beforeAll, afterAll, it, expect, afterEach } from
 import { strict as assert } from "node:assert";
 
 const PORT = 4567;
+const RESPONSE_FILE = "./response.txt";
 
 type ImpactedTargets = string[] | "ALL";
 
@@ -18,7 +19,7 @@ type EnvVar =
   | "REPOSITORY"
   | "TARGET_BRANCH"
   | "PR_NUMBER"
-  | "PR_SHA"
+  | "PR_BRANCH_HEAD_SHA"
   | "IMPACTED_TARGETS_FILE"
   | "IMPACTS_ALL_DETECTED"
   | "API_URL"
@@ -34,7 +35,7 @@ const DEFAULT_ENV_VARIABLES: EnvVarSet = {
   REPOSITORY: "test-repo-owner/test-repo-name",
   TARGET_BRANCH: "test-target-branch",
   PR_NUMBER: "123",
-  PR_SHA: "test-pr-sha",
+  PR_BRANCH_HEAD_SHA: "test-pr-sha",
   IMPACTED_TARGETS_FILE: "/tmp/test-impacted-targets-file",
   IMPACTS_ALL_DETECTED: "false",
   API_URL: fetchUrl("/testUploadImpactedTargets"),
@@ -81,7 +82,8 @@ describe("upload_impacted_targets", () => {
     assert(exportedEnvVars);
     assert(uploadedImpactedTargetsPayload);
 
-    const { API_TOKEN, REPOSITORY, TARGET_BRANCH, PR_NUMBER, PR_SHA, RUN_ID } = exportedEnvVars;
+    const { API_TOKEN, REPOSITORY, TARGET_BRANCH, PR_NUMBER, PR_BRANCH_HEAD_SHA, RUN_ID } =
+      exportedEnvVars;
     const { apiTokenHeader, forkedWorkflowIdHeader, requestBody } = uploadedImpactedTargetsPayload;
 
     expect(apiTokenHeader).toEqual(API_TOKEN);
@@ -94,7 +96,7 @@ describe("upload_impacted_targets", () => {
       },
       pr: {
         number: PR_NUMBER,
-        sha: PR_SHA,
+        sha: PR_BRANCH_HEAD_SHA,
       },
       targetBranch: TARGET_BRANCH,
       impactedTargets,
@@ -131,6 +133,7 @@ describe("upload_impacted_targets", () => {
 
   afterEach(function () {
     fs.rmSync(DEFAULT_ENV_VARIABLES.IMPACTED_TARGETS_FILE, { force: true });
+    fs.rmSync(RESPONSE_FILE, { force: true });
   });
 
   afterAll(function () {


### PR DESCRIPTION
## What Does The PR Do
This PR properly handles uploading impacted targets from forked PRs. This required some changes with how we check out branches from PRs - mainly, switching to the SHA instead of the ref/branch name

## Testing
This was tested with two PRs using the most current SHA of this action (`7892141d5667431db80de9b7c8fd82378c7390bd`) - one was forked, and one was not

**Forked**
* https://github.com/pv72895/phil-test-repo/pull/29
* [Successful upload of impacted targets](https://github.com/pv72895/phil-test-repo/actions/runs/7907782805/job/21585582453?pr=29)

**Not forked**
* https://github.com/pv72895/phil-test-repo/pull/30
* [Successful upload of impacted targets](https://github.com/pv72895/phil-test-repo/actions/runs/7907814712/job/21585684986?pr=30)

## Other things done in the PR
I made it so that we also print out the response body from the API call to upload impacted targets if we don't get a 200 back, which should make it much clearer as to what went wrong