### PR TITLE
fix: bazel diff artifact rename

### DIFF
--- a/src/scripts/compute_impacted_targets.sh
+++ b/src/scripts/compute_impacted_targets.sh
@@ -78,7 +78,8 @@ if [[ -n ${VERBOSE} ]]; then
 fi
 
 # Install the bazel-diff JAR. Avoid cloning the repo, as there will be conflicting WORKSPACES.
-curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
+curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar --fail || \
+	curl --retry 5 -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy-7.jar
 _java -jar bazel-diff.jar -V
 _bazel version # Does not require running with startup options.
 


### PR DESCRIPTION
Checks the old name, then the new